### PR TITLE
Don't look for posts to process in the vendor directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,3 +120,4 @@ exclude:
   - README.md
   - Gemfile*
   - LICENSE
+  - vendor


### PR DESCRIPTION
for those who vendor their gems

I installed gems with `bundle install --path=vendor` to prevent gems from being installed in my global gemset, and that resulted in this error when I tried to run the site:

```
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/ruby/2.1.0/gems/jekyll-3.1.6/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
```

Adding the `vendor` directory to the list of places to ignore fixed this. I think it's safe to ignore that directory.