### PR TITLE
Bugfix | Reduce width of logo on viewports with a width of 320px

### DIFF
--- a/_includes/css/agency.css
+++ b/_includes/css/agency.css
@@ -176,9 +176,9 @@ fieldset[disabled] .btn-xl.active {
 }
 
 .navbar-default .navbar-brand {
-    width: 256px;
+    width: 220px;
     height: 35px;
-    margin-top: 11px;
+    margin-top: 16px;
     margin-left: 10px;
     color: transparent;
     font-size: 0;


### PR DESCRIPTION
This PR fixes:
* A UI bug that Yih En reported via slack:

<img width="338" alt="Screenshot 2019-03-18 09 58 45" src="https://user-images.githubusercontent.com/1836842/54502231-73ceca00-4964-11e9-8d3b-910e55d2a9ae.png">
