### PR TITLE
Bugfix | Safari display bugs

### DIFF
--- a/_scss/blog/_blog-list.scss
+++ b/_scss/blog/_blog-list.scss
@@ -19,7 +19,7 @@
     .content {
       @include flex-column;
       justify-content: end;
-      height: 60%;
+      height: 75%;
       padding: 20px;
       border-bottom-left-radius: 30px;
       border-bottom-right-radius: 30px;
@@ -82,7 +82,7 @@
       }
 
       .content {
-        height: 60%;
+        height: 90%;
         border-top-left-radius: 30px;
         border-top-right-radius: 30px;
       }
@@ -114,7 +114,7 @@
       }
 
       .content {
-        height: 60%;
+        height: 70%;
       }
     }
   }

--- a/_scss/services/_solutions.scss
+++ b/_scss/services/_solutions.scss
@@ -145,7 +145,7 @@
 
   .solution-item {
     flex-direction: row;
-    flex: 1 1 0px;
+    flex: auto;
     margin-bottom: 100px;
 
     .intro {


### PR DESCRIPTION
This PR:
- Fixes a bug found when using iPad Safari. This was caused by the fact that Safari does not seem to like it when the `flex` shorthand is used. 
- Fixes heights for blog post tiles on Safari (again caused because flex behaves differently)

## Safari iPad bug
![IMG_0204](https://user-images.githubusercontent.com/1836842/103785913-b8b27c00-5076-11eb-8160-a17da5abac05.PNG)
